### PR TITLE
Skip processing for non-convex MeshCollider

### DIFF
--- a/Packages/Tracking/Physical Hands/Runtime/Scripts/ContactBone.cs
+++ b/Packages/Tracking/Physical Hands/Runtime/Scripts/ContactBone.cs
@@ -223,13 +223,21 @@ namespace Leap.PhysicalHands
 
                 if (IsPalm)
                 {
-                    // Do palm logic
-                    colliderPos = ContactUtils.ClosestPointEstimationFromRectangle(_palmColCenter, _palmColRotation, _palmExtentsReduced.xz(), collider);
-                    bonePos = ContactUtils.ClosestPointToRectangleFace(_palmPoints, _palmPlane.ClosestPointOnPlane(colliderTransformPosition));
-                    midPoint = colliderPos + (bonePos + ((bonePos - colliderPos).normalized * width) - colliderPos) / 2f;
+                    if (collider is BoxCollider || collider is SphereCollider || collider is CapsuleCollider || (collider is MeshCollider meshCollider && meshCollider.convex))
+                    {
+                        // Do palm logic
+                        colliderPos = ContactUtils.ClosestPointEstimationFromRectangle(_palmColCenter, _palmColRotation, _palmExtentsReduced.xz(), collider);
+                        bonePos = ContactUtils.ClosestPointToRectangleFace(_palmPoints, _palmPlane.ClosestPointOnPlane(colliderTransformPosition));
+                        midPoint = colliderPos + (bonePos + ((bonePos - colliderPos).normalized * width) - colliderPos) / 2f;
 
-                    colliderPos = collider.ClosestPoint(midPoint);
-                    bonePos = ContactUtils.ClosestPointToRectangleFace(_palmPoints, _palmPlane.ClosestPointOnPlane(midPoint));
+                        colliderPos = collider.ClosestPoint(midPoint);
+                        bonePos = ContactUtils.ClosestPointToRectangleFace(_palmPoints, _palmPlane.ClosestPointOnPlane(midPoint));
+                    }
+                    else
+                    {
+                        // Skip processing for non-convex MeshCollider
+                        continue;
+                    }
                 }
                 else
                 {
@@ -238,14 +246,22 @@ namespace Leap.PhysicalHands
                     float lineLength = lineDir.magnitude;
                     lineDir.Normalize();
 
-                    colliderPos = collider.ClosestPoint((boneTransformPosition + tipPosition) * 0.5f);
-                    // Do joint logic
-                    bonePos = ContactUtils.GetClosestPointOnFiniteLine(colliderTransformPosition, boneTransformPosition, lineDir, lineLength);
-                    // We need to extrude the line to get the bone's edge
-                    midPoint = colliderPos + (bonePos + ((bonePos - colliderPos).normalized * width) - colliderPos) / 2f;
+                    if (collider is BoxCollider || collider is SphereCollider || collider is CapsuleCollider || (collider is MeshCollider meshCollider && meshCollider.convex))
+                    {
+                        colliderPos = collider.ClosestPoint((boneTransformPosition + tipPosition) * 0.5f);
+                        // Do joint logic
+                        bonePos = ContactUtils.GetClosestPointOnFiniteLine(colliderTransformPosition, boneTransformPosition, lineDir, lineLength);
+                        // We need to extrude the line to get the bone's edge
+                        midPoint = colliderPos + (bonePos + ((bonePos - colliderPos).normalized * width) - colliderPos) / 2f;
 
-                    colliderPos = collider.ClosestPoint(midPoint);
-                    bonePos = ContactUtils.GetClosestPointOnFiniteLine(midPoint, boneTransformPosition, lineDir, lineLength);
+                        colliderPos = collider.ClosestPoint(midPoint);
+                        bonePos = ContactUtils.GetClosestPointOnFiniteLine(midPoint, boneTransformPosition, lineDir, lineLength);
+                    }
+                    else
+                    {
+                        // Skip processing for non-convex MeshCollider
+                        continue;
+                    }
                 }
 
                 distance = Vector3.Distance(colliderPos, bonePos);


### PR DESCRIPTION
## Summary

_Add a Summary here._

## Contributor Tasks

- [ ] Create or edit test cases [here](https://ultrahaptics.atlassian.net/projects/UNITY?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/v2/testCases?projectId=15189)
- [ ] Add a CHANGELOG entry for this change.
- [ ] Ensure documentation requirements are met e.g., public API is commented.
- [ ] Consider any licensing/other legal implications for this MR e.g. notices required by any new libraries.

## Test Cycle

_Link to the test cycle here._

## Reviewer Tasks

- [ ] Code reviewed.
- [ ] Non-code assets e.g. Unity assets/scenes reviewed.
- [ ] All tests must be ran and cover all scenarios (If not, add new tests to the cycle and run them).
- [ ] Documentation has been reviewed.
- [ ] Approve with a comment of any additional tests run or any observations.

## Related JIRA Issues

_If this MR closes any JIRA issues list them below in the form `Closes PROJECT-#`_

## Pull Request Templates

Switch template by going to preview and clicking the link - note it will not work if you've made any changes to the description.

- [default.md](?expand=1) - for contributions to stable packages.
- [release.md](?expand=1&template=release.md) - for release merge requests.

**You are currently using: default.md**

Note: these links work by overwriting query parameters of the current url. If the current url contains any you may want to amend the url with `&template=name.md` instead of using the link. See [query parameter docs](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/using-query-parameters-to-create-a-pull-request) for more information.
